### PR TITLE
Addin SecureBulkLoadEndpoint to hbase-site secure (kerberos) config.

### DIFF
--- a/cdh5/etc/hbase/conf/hbase-site.xml
+++ b/cdh5/etc/hbase/conf/hbase-site.xml
@@ -99,7 +99,7 @@
     </property>
     <property>
         <name>hbase.coprocessor.region.classes</name>
-        <value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController</value>
+        <value>org.apache.hadoop.hbase.security.token.TokenProvider,org.apache.hadoop.hbase.security.access.AccessController,org.apache.hadoop.hbase.security.access.SecureBulkLoadEndpoint</value>
     </property>
     <property>
         <name>hbase.thrift.keytab.file</name>


### PR DESCRIPTION
We need this in order for the hbase bulkload to work.
