### PR TITLE
Modified the mapred file output format to use default compression and ma...

### DIFF
--- a/cdh5/etc/hadoop/conf/mapred-site.xml
+++ b/cdh5/etc/hadoop/conf/mapred-site.xml
@@ -50,7 +50,7 @@
      <value>false</value>
    </property>
   <property>
-    <name>mapreduce.output.fileoutputformat.compress.codec</name>
+    <name>mapreduce.map.output.compress.codec</name>
     <value>org.apache.hadoop.io.compress.SnappyCodec</value>
   </property>
   <property>


### PR DESCRIPTION
...p output to use snappy compression

Corrected the cdh5 configuration to match the cdh4 config.  For hdfs job outputs we want to use default compression because it takes less disk space.  For intermediate map output we want to use snappy compression because it is faster.
