### PR TITLE
expose setting mapreduce.job.split.metainfo.maxsize in mapred_site.xm…

### DIFF
--- a/SPECFILE
+++ b/SPECFILE
@@ -98,6 +98,7 @@ pillar_defaults:
       memory_mb: 2048
       reduces: 3
       heap_dump_path: /mnt
+      metainfo_maxsplit: 10000000
     hbase:
       start_service: true
       tmp_dir: /mnt/hbase/tmp

--- a/cdh5/etc/hadoop/conf/mapred-site.xml
+++ b/cdh5/etc/hadoop/conf/mapred-site.xml
@@ -27,6 +27,12 @@
     <value>{{ pillar.cdh5.mapred.reduces }}</value>
   </property>
 
+  {% set metainfo_split = salt['pillar.get']('cdh5:mapred:metainfo_maxsplit', '10000000') %}
+  <property>
+    <name>mapreduce.job.split.metainfo.maxsize</name>
+    <value>{{ metainfo_split }}</value>
+  </property>
+
   <!-- Compression -->
   <property>
      <name>mapreduce.output.fileoutputformat.compress</name>


### PR DESCRIPTION
…l, defaulting to hadoop default value